### PR TITLE
10-gas price needs to be updated

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -93,7 +93,7 @@ module.exports = {
       },
       network_id: '1001', //Klaytn baobab testnet's network id
       gas: '8500000',
-      gasPrice:'25000000000'
+      gasPrice:'750000000000'
     },
     kasCypress: {
       provider: () => {
@@ -108,7 +108,7 @@ module.exports = {
       },
       network_id: '8217', //Klaytn baobab testnet's network id
       gas: '8500000',
-      gasPrice:'25000000000'
+      gasPrice:'750000000000'
     },
     baobab: {
       provider: () => { return new HDWalletProvider(testnetPrivateKey, testnetApiUrl) },


### PR DESCRIPTION
## Proposed changes

- gasPrice value is updated to 750 ston for baobab and cypress,   in truffle-config.js.  (which [aidan-kwon] raised the issue)