### PR TITLE
fix network/init_accounts.js error

### DIFF
--- a/network/init_accounts.js
+++ b/network/init_accounts.js
@@ -13,7 +13,7 @@ async function initAccounts(numAccounts) {
       const p = caver.wallet.keyring.generate()
       privateKeys.push(p.key.privateKey)
 
-      const vt = new caver.transaction.valueTransfer({
+      const vt = caver.transaction.valueTransfer.create({
         from: fundAddr,
         to: p.address,
         value: caver.utils.toPeb(100, 'KLAY'),


### PR DESCRIPTION

## Proposed changes
```js
new caver.transaction.valueTransfer() ->>> caver.transaction.valueTransfer.create()
```

## Types of changes

- [X] Bugfix
